### PR TITLE
setup: do not zip egg when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms=["any"],
-    zip_safe=True,
+    zip_safe=False,
     install_requires=install_requires,
     long_description=long_description,
 


### PR DESCRIPTION
leaflet_storage does not work when egg is installed as zipped archive. Force setup.py to install as unzipped directory.

I tried 'runserver' and apache in wsgi mode. When I run "python setup.py build" and "python setup.py install" it will only work with zip_safe=False.