### PR TITLE
MapManager (replaces PublicManager)

### DIFF
--- a/leaflet_storage/managers.py
+++ b/leaflet_storage/managers.py
@@ -1,8 +1,8 @@
 from django.contrib.gis.db import models
+from django.db.models import Q
 
+class MapManager(models.GeoManager):
+    def visible(self, request):
+        filter = Q(share_status=self.model.PUBLIC)
 
-class PublicManager(models.GeoManager):
-
-    def get_queryset(self):
-        return super(PublicManager, self).get_queryset().filter(
-            share_status=self.model.PUBLIC)
+        return self.filter(filter)

--- a/leaflet_storage/managers.py
+++ b/leaflet_storage/managers.py
@@ -4,5 +4,7 @@ from django.db.models import Q
 class MapManager(models.GeoManager):
     def visible(self, request):
         filter = Q(share_status=self.model.PUBLIC)
+        filter = filter | Q(owner=request.user)
+        filter = filter | Q(editors=request.user)
 
         return self.filter(filter)

--- a/leaflet_storage/models.py
+++ b/leaflet_storage/models.py
@@ -13,7 +13,7 @@ from django.template.defaultfilters import slugify
 from django.core.files.base import File
 
 from .fields import DictField
-from .managers import PublicManager
+from .managers import MapManager
 
 
 class NamedModel(models.Model):
@@ -139,8 +139,7 @@ class Map(NamedModel):
     share_status = models.SmallIntegerField(choices=SHARE_STATUS, default=PUBLIC, verbose_name=_("share status"))
     settings = DictField(blank=True, null=True, verbose_name=_("settings"))
 
-    objects = models.GeoManager()
-    public = PublicManager()
+    objects = MapManager()
 
     def get_absolute_url(self):
         return reverse("map", kwargs={'slug': self.slug or "map", 'pk': self.pk})


### PR DESCRIPTION
I think the PublicManager is not an ideal solution. This pull request replaces PublicManager by a MapManager with a visible() filter which takes the request object as parameter. It adds additional filters, so that maps of the current user are also included. This also simplifies adding additional permissions.