### PR TITLE
Make DictField compliant with dumpdata/loaddata

### DIFF
--- a/leaflet_storage/fields.py
+++ b/leaflet_storage/fields.py
@@ -2,6 +2,7 @@ import json
 
 from django.utils import six
 from django.db import models
+from django.utils.encoding import smart_text
 
 
 class DictField(models.TextField):
@@ -26,3 +27,7 @@ class DictField(models.TextField):
             return json.loads(value)
         else:
             return value
+
+    def value_to_string(self, obj):
+        """Return value from object converted to string properly"""
+        return smart_text(self.get_prep_value(self._get_val_from_obj(obj)))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from leaflet_storage.models import Map
@@ -31,3 +33,11 @@ def test_should_not_double_dumps(map):
     map.settings = '{"locate": true}'
     map.save()
     assert Map.objects.get(pk=map.pk).settings == {'locate': True}
+
+
+def test_value_to_string(map):
+    d = {'locateControl': True}
+    map.settings = d
+    map.save()
+    field = Map._meta.get_field('settings')
+    assert json.loads(field.value_to_string(map)) == d


### PR DESCRIPTION
Otherwise it gets dumped like a dict, which cannot then be loaded back.